### PR TITLE
ci: add on_merge workflow to trigger publish on release PR merge

### DIFF
--- a/.github/workflows/on_merge.yml
+++ b/.github/workflows/on_merge.yml
@@ -1,0 +1,35 @@
+name: On Release PR Merged
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  dispatch:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Fire repository_dispatch to dev repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEV_REPO_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'appier',
+              repo: 'appier-ads-ios-admob-mediation',
+              event_type: 'release_merged',
+              client_payload: {
+                version: '${{ steps.version.outputs.version }}'
+              }
+            });
+            core.info('Dispatched release_merged for ${{ steps.version.outputs.version }}');


### PR DESCRIPTION
## Summary

Adds `.github/workflows/on_merge.yml` — fires a `repository_dispatch` to the dev repo (`appier-ads-ios-admob-mediation`) when a `release/v*` PR is merged to master.

## How it works

1. Release PR (`release/vX.X.X` → `master`) is merged
2. `on_merge.yml` extracts the version from the branch name
3. Sends `release_merged` event to `appier-ads-ios-admob-mediation` using `DEV_REPO_DISPATCH_TOKEN`
4. `publish.yml` in the dev repo triggers — creates git tag + runs `pod trunk push`

## Security

Only `DEV_REPO_DISPATCH_TOKEN` is needed here (Contents write on dev repo only). No sensitive tokens live in this public repo.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)